### PR TITLE
Add "homepage" and link podspec

### DIFF
--- a/CertPinner.podspec
+++ b/CertPinner.podspec
@@ -1,0 +1,1 @@
+ios/CertPinner.podspec

--- a/ios/CertPinner.podspec
+++ b/ios/CertPinner.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   CertPinner
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/approov/react-native-cert-pinner"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
In order to make this work for me, I had to add the homepage prop. Also the, podspec file needs to be in the root of the repo in order to link it like this:

    pod 'TrustKit', '~> 1.4.2'
    pod 'CertPinner', :git => 'https://github.com/approov/react-native-cert-pinner.git'

Here's the original error:

    [!] The `CertPinner` pod failed to validate due to 1 error:
        - ERROR | attributes: Missing required attribute `homepage`.
        - WARN  | source: The version should be included in the Git tag.
        - WARN  | description: The description is equal to the summary.

and

    [!] Unable to find a specification for 'CertPinner'.

Would be super if you could merge this back so I can get rid of my fork 🙏